### PR TITLE
Add handling for UTF-8 BOM encoded insights files

### DIFF
--- a/client/searchClient.py
+++ b/client/searchClient.py
@@ -42,7 +42,7 @@ class SearchClient(ClientAbstract):
                 json_object = json.loads(
                     self.storage_client.get_blob_string(
                         self.config["storage"]["container"], file.name
-                    )
+                    ).encode()  # Encode as UTF-8 in case UTF-8 BOM
                 )
                 if json_object["state"] == "Processed":
                     parser = Parser()


### PR DESCRIPTION
Hi, found that by default, some insights file were UTF-8 BOM encoded, which can cause errors with parsing after they're retrieved: 

```
Traceback (most recent call last):
  File "/Users/mason/Projects/own/azureVISearchableContent/main.py", line 12, in <module>
    SEARCH_CLIENT.upload_files_from_storage_to_search()
  File "/Users/mason/Projects/own/azureVISearchableContent/client/searchClient.py", line 66, in upload_files_from_storage_to_search
    self.write_status_file(file, self.config["files"]["failed-to-ingest-file"])
  File "/Users/mason/Projects/own/azureVISearchableContent/client/clientabstract.py", line 29, in write_status_file
    f.write(file + "\n")
TypeError: unsupported operand type(s) for +: 'BlobProperties' and 'str'
```

Calling `.encode()` on the content appears to force them to use standard UTF-8, avoiding this.